### PR TITLE
Persistent data via shelve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 
 # vscode workspace settings
 .vscode
+
+# data storage
+*.bak
+*.dat
+*.dir

--- a/py/src/cards.py
+++ b/py/src/cards.py
@@ -13,6 +13,28 @@ JOKER_NUMBER = 15
 JOKER_NUMBER_CHAR = "joker"
 
 
+# Data for card deck, intended to be synchronized via a sync manager
+class CardsData:
+    def __init__(self):
+        self.card_deck = shuffle(build_deck_52())
+        self.card_logs = []
+
+    def get_card_deck(self):
+        return self.card_deck
+
+    def set_card_deck(self, deck):
+        self.card_deck = deck
+
+    def get_card_logs(self):
+        return self.card_logs
+
+    def clear_card_logs(self):
+        self.card_logs = []
+
+    def add_card_log(self, message):
+        self.card_logs.append(message)
+
+
 @total_ordering
 class Card(namedtuple("CardId", ["n", "s"])):
     NUMBERS = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]

--- a/py/src/cards.py
+++ b/py/src/cards.py
@@ -28,6 +28,9 @@ class CardsData:
     def get_card_logs(self):
         return self.card_logs
 
+    def set_card_logs(self, logs):
+        self.card_logs = logs
+
     def clear_card_logs(self):
         self.card_logs = []
 

--- a/py/src/client.py
+++ b/py/src/client.py
@@ -113,7 +113,7 @@ class MidHelpCommand(commands.DefaultHelpCommand):
         self.end_codeblock()
 
 
-@discord.app_commands.command(name="help", description="Shows help.")
+@discord.app_commands.command(name="help", description="Shows help")
 async def help_app_command(interaction: discord.Interaction, command: Optional[str]):
     bot: MidClient = interaction.client  # type: ignore
     if bot.help_command is None:

--- a/py/src/client.py
+++ b/py/src/client.py
@@ -30,15 +30,21 @@ class Storage:
         self.load()
 
     def load(self):
-        self.fields = {}
-        with shelve.open(self.filename) as db:
-            for key in db.keys():
-                self.fields[key] = db[key]
+        try:
+            with shelve.open(self.filename) as db:
+                self.fields = {}
+                for key in db.keys():
+                    self.fields[key] = db[key]
+        except OSError as e:
+            log.error(f"Failed to load from storage.", e, exc_info=True)
 
     def save(self):
-        with shelve.open(self.filename) as db:
-            for key in self.fields.keys():
-                db[key] = self.fields[key]
+        try:
+            with shelve.open(self.filename) as db:
+                for key in self.fields.keys():
+                    db[key] = self.fields[key]
+        except OSError as e:
+            log.error(f"Failed to save data to storage.", e, exc_info=True)
 
     def set(self, key: str, data):
         self.fields[key] = data

--- a/py/src/client.py
+++ b/py/src/client.py
@@ -35,16 +35,21 @@ class Storage:
                 self.fields = {}
                 for key in db.keys():
                     self.fields[key] = db[key]
+            return False
         except OSError as e:
             log.error(f"Failed to load from storage.", e, exc_info=True)
+            return True
 
     def save(self):
         try:
             with shelve.open(self.filename) as db:
                 for key in self.fields.keys():
                     db[key] = self.fields[key]
+            log.info("Saved bot data to local storage.")
+            return False
         except OSError as e:
             log.error(f"Failed to save data to storage.", e, exc_info=True)
+            return True
 
     def set(self, key: str, data):
         self.fields[key] = data
@@ -166,7 +171,6 @@ class MidClient(commands.Bot):
     @tasks.loop(seconds=STORAGE_SAVE_INTERVAL)
     async def save_storage(self):
         self.get_storage().save()
-        log.info("Saved bot data to local storage.")
 
     async def setup_hook(self) -> None:
         await super().setup_hook()

--- a/py/src/cogs/artificial_cog.py
+++ b/py/src/cogs/artificial_cog.py
@@ -5,6 +5,7 @@ import artificial
 import discord
 import openai
 from cmds import swap_hybrid_command_description
+from cogs.base_cog import BaseCog
 from discord.ext import commands
 from utils import *
 
@@ -18,8 +19,9 @@ IMAGE_GEN_TITLE = "DALL-E"
 OAI_DEFAULT_IMAGE_SIZE = "512x512"
 
 
-class Intelligence(commands.Cog):
+class Intelligence(BaseCog):
     def __init__(self, bot) -> None:
+        super().__init__(bot)
         swap_hybrid_command_description(self.complete)
         swap_hybrid_command_description(self.genimage)
         swap_hybrid_command_description(self.parameters)

--- a/py/src/cogs/base_cog.py
+++ b/py/src/cogs/base_cog.py
@@ -1,0 +1,12 @@
+# Base class for mid-bot cogs
+import logging
+
+from client import MidClient
+from discord.ext import commands
+
+log = logging.getLogger(__name__)
+
+
+class BaseCog(commands.Cog):
+    def __init__(self, bot: MidClient) -> None:
+        self.bot = bot

--- a/py/src/cogs/cards_cog.py
+++ b/py/src/cogs/cards_cog.py
@@ -20,7 +20,6 @@ class Cards(BaseCog):
         self.data: cards.CardsData = bot.get_sync_manager().CardsData()  # type: ignore
 
         self.load_from_storage()
-        self.update_storage()
 
         swap_hybrid_command_description(self.deck)
 
@@ -32,7 +31,7 @@ class Cards(BaseCog):
             self.data.set_card_logs(logs)
             log.info("Loaded card deck and logs from storage.")
         except KeyError as e:
-            log.error(f"No card data found in storage.", e)
+            log.error(f"No card data found in storage.")
 
     def update_storage(self):
         self.bot.get_storage().set(Cards.CARD_DECK_KEY, self.data.get_card_deck())

--- a/py/src/cogs/cards_cog.py
+++ b/py/src/cogs/cards_cog.py
@@ -4,37 +4,17 @@ import typing
 
 import cards
 from cmds import as_subprocess_command, swap_hybrid_command_description
+from cogs.base_cog import BaseCog
 from discord.ext import commands
 from utils import *
 
 log = logging.getLogger(__name__)
 
 
-# Data for card deck, intended to be synchronized via a sync manager
-class CardsData:
-    def __init__(self):
-        self.card_deck = cards.shuffle(cards.build_deck_52())
-        self.card_logs = []
-
-    def get_card_deck(self):
-        return self.card_deck
-
-    def set_card_deck(self, deck):
-        self.card_deck = deck
-
-    def get_card_logs(self):
-        return self.card_logs
-
-    def clear_card_logs(self):
-        self.card_logs = []
-
-    def add_card_log(self, message):
-        self.card_logs.append(message)
-
-
-class Cards(commands.Cog):
+class Cards(BaseCog):
     def __init__(self, bot):
-        self.data: CardsData = bot.get_sync_manager().CardsData()
+        super().__init__(bot)
+        self.data: cards.CardsData = bot.get_sync_manager().CardsData()  # type: ignore
         swap_hybrid_command_description(self.deck)
 
     def add_history_log(self, ctx: commands.Context, reply: str) -> str:
@@ -104,33 +84,33 @@ class Cards(commands.Cog):
         await self.as_card_operation(ctx, _history, count)
 
 
-def _draw(card_data: CardsData, count: int) -> str:
+def _draw(card_data: cards.CardsData, count: int) -> str:
     cdeck = card_data.get_card_deck()
     drawn = cards.draw(cdeck, count)
     card_data.set_card_deck(cdeck)
     return str(drawn)
 
 
-def _reset(card_data: CardsData) -> str:
+def _reset(card_data: cards.CardsData) -> str:
     cdeck = cards.shuffle(cards.build_deck_52())
     card_data.set_card_deck(cdeck)
     return "Deck reset and shuffled."
 
 
-def _shuffle(card_data: CardsData) -> str:
+def _shuffle(card_data: cards.CardsData) -> str:
     cdeck = cards.shuffle(card_data.get_card_deck())
     card_data.set_card_deck(cdeck)
     return "Deck shuffled."
 
 
-def _inspect(card_data: CardsData) -> str:
+def _inspect(card_data: cards.CardsData) -> str:
     cdeck = card_data.get_card_deck()
     top = cdeck[len(cdeck) - 1] if len(cdeck) > 0 else None
     bot = cdeck[0] if len(cdeck) > 0 else None
     return f"{len(cdeck)} cards in deck. Top card is {top}. Bottom card is {bot}."
 
 
-def _history(card_data: CardsData, count: int) -> str:
+def _history(card_data: cards.CardsData, count: int) -> str:
     history = card_data.get_card_logs()
     numbered = [f"{i+1}: {history[i]}" for i in range(len(history))][-count:]
     output = "\n".join(numbered)

--- a/py/src/cogs/deafen_cog.py
+++ b/py/src/cogs/deafen_cog.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timedelta
 
 from cmds import swap_hybrid_command_description
+from cogs.base_cog import BaseCog
 from discord.ext import commands
 from utils import *
 
@@ -13,8 +14,9 @@ MAX_DEAFEN_SECONDS = 300
 UNDEAFEN_CMD_NAME = "undeafen"
 
 
-class Deafener(commands.Cog):
+class Deafener(BaseCog):
     def __init__(self, bot) -> None:
+        super().__init__(bot)
         self.time_for_undeafen: datetime | None = None
         swap_hybrid_command_description(self.deafen)
         swap_hybrid_command_description(self.undeafen)

--- a/py/src/cogs/dice_cog.py
+++ b/py/src/cogs/dice_cog.py
@@ -34,7 +34,6 @@ class DiceRoller(BaseCog):
 
         self.add_default_macros()
         self.load_stored_macros()
-        self.update_storage()
 
     def add_default_macros(self):
         self.macro_data.add_macro("stats", "repeat(4d6kh3, 6)")
@@ -50,7 +49,7 @@ class DiceRoller(BaseCog):
                 self.macro_data.add_macro(n, c)
                 log.info(f"Loaded macro {n} = {c}")
         except KeyError as e:
-            log.error(f"No macro data found in storage.", e)
+            log.error(f"No macro data found in storage.")
 
     def update_storage(self):
         self.bot.get_storage().set(

--- a/py/src/cogs/dice_cog.py
+++ b/py/src/cogs/dice_cog.py
@@ -3,6 +3,7 @@ import logging
 
 import dice
 from cmds import as_subprocess_command, swap_hybrid_command_description
+from cogs.base_cog import BaseCog
 from discord.ext import commands
 from utils import *
 
@@ -20,9 +21,10 @@ def _roll(formula: str, macro_data: dice.MacroData) -> str:
     return output
 
 
-class DiceRoller(commands.Cog):
+class DiceRoller(BaseCog):
     def __init__(self, bot) -> None:
-        self.macro_data: dice.MacroData = bot.get_sync_manager().MacroData()
+        super().__init__(bot)
+        self.macro_data: dice.MacroData = bot.get_sync_manager().MacroData()  # type: ignore
         self.add_default_macros()
         swap_hybrid_command_description(self.roll)
         swap_hybrid_command_description(self.macros)

--- a/py/src/cogs/dice_cog.py
+++ b/py/src/cogs/dice_cog.py
@@ -29,12 +29,12 @@ class DiceRoller(BaseCog):
         super().__init__(bot)
         self.macro_data: dice.MacroData = bot.get_sync_manager().MacroData()  # type: ignore
 
+        swap_hybrid_command_description(self.roll)
+        swap_hybrid_command_description(self.macros)
+
         self.add_default_macros()
         self.load_stored_macros()
         self.update_storage()
-
-        swap_hybrid_command_description(self.roll)
-        swap_hybrid_command_description(self.macros)
 
     def add_default_macros(self):
         self.macro_data.add_macro("stats", "repeat(4d6kh3, 6)")
@@ -49,8 +49,6 @@ class DiceRoller(BaseCog):
             for n, c in loaded.items():
                 self.macro_data.add_macro(n, c)
                 log.info(f"Loaded macro {n} = {c}")
-        except OSError as e:
-            log.error(f"Failed to load from storage.", e, exc_info=True)
         except KeyError as e:
             log.error(f"No macro data found in storage.", e)
 

--- a/py/src/cogs/maintenance_cog.py
+++ b/py/src/cogs/maintenance_cog.py
@@ -1,0 +1,29 @@
+# Cog for ensuring that bot data is stored before maintenance
+
+from cmds import swap_hybrid_command_description
+from config import STORAGE_SAVE_INTERVAL
+from cogs.base_cog import BaseCog
+from discord.ext import commands
+from utils import reply
+
+
+class Maintenance(BaseCog):
+    def __init__(self, bot) -> None:
+        super().__init__(bot)
+        swap_hybrid_command_description(self.forcesave)
+
+    @commands.hybrid_command(
+        brief="Save the bot's persistent data",
+        description=f"""
+    __**forcesave**__
+    Immediately save bot data to persistent storage.
+    Normally, the bot does this automatically every {STORAGE_SAVE_INTERVAL} seconds.
+    """,
+    )
+    async def forcesave(self, ctx: commands.Context):
+        errored = self.bot.get_storage().save()
+        if errored:
+            await reply(ctx, "Encountered error while saving. Check the logs.")
+            return
+        else:
+            await reply(ctx, "Succesfully stored data.")

--- a/py/src/cogs/remind_cog.py
+++ b/py/src/cogs/remind_cog.py
@@ -84,9 +84,6 @@ class RemindEntry:
 
     async def get_context(self, bot: commands.Bot) -> commands.Context:
         if self._context is None:
-            log.info(
-                f"channel id: {self.channel_id}, req message id: {self.request_id}"
-            )
             c = bot.get_partial_messageable(self.channel_id)
             if c is None:
                 c = await bot.fetch_channel(self.channel_id)
@@ -127,8 +124,9 @@ class RemindEntry:
         )
 
     async def send(self, bot: commands.Bot):
-        reminders = await self.target_mentions(bot)
-        decorated = reminders + "\nReminder: " + self.text
+        log.info(f"Reminder firing: {self}")
+        mentions = await self.target_mentions(bot)
+        decorated = mentions + "\nReminder: " + self.text
         ctx = bot.get_partial_messageable(self.channel_id)
         try:
             ctx = await self.get_context(bot)
@@ -420,7 +418,7 @@ class Reminder(BaseCog):
             response = re.get_response(self.bot)
             if response:
                 await response.edit(content="Reminder cancelled.", view=None)
-            await reply(ctx, f"Cancelled reminder: {re}")
+            await reply(ctx, f"Cancelled reminder: {await re.describe(self.bot)}")
 
 
 class ReminderMeTooButton(discord.ui.Button):

--- a/py/src/cogs/remind_cog.py
+++ b/py/src/cogs/remind_cog.py
@@ -34,21 +34,21 @@ class RemindEntry:
         targets: list[discord.User | discord.Member],
         reply: discord.Message | None = None,
     ) -> None:
-        self.text = text
-        self.time = time
-        self.target_ids = [t.id for t in targets]
-        self.author_id = context.author.id
-        self.channel_id = context.channel.id
-        self.request_id = context.message.id
+        self.text: str = text
+        self.time: datetime = time
+        self.target_ids: list[int] = [t.id for t in targets]
+        self.author_id: int = context.author.id
+        self.channel_id: int = context.channel.id
+        self.request_id: int = context.message.id
         if context.interaction:
-            self.interaction = True
+            self.interaction: bool = True
         else:
-            self.interaction = False
-        self.response_id = reply.id if reply else None
+            self.interaction: bool = False
+        self.response_id: int | None = reply.id if reply else None
 
-        # cache-like, these won't change once fetched
-        self._request = context.message
-        self._context = context
+        # cache-like discord models; these won't change once fetched but aren't persisted in storage.
+        self._request: discord.Message | discord.PartialMessage | None = context.message
+        self._context: commands.Context | None = context
 
     def __repr__(self) -> str:
         return f"Reminder at {short_format_time(self.time)} for {','.join(str(tid) for tid in self.target_ids)}: {self.text}"
@@ -290,7 +290,6 @@ class Reminder(BaseCog):
     The bot will mention you in a message within a minute of the set time, in the same channel the command was used.
     It will attempt to parse your requested time, allowing for requests like `{get_summon_prefix()}remind "in 30 minutes" check the oven`.
     If AM/PM is unspecified, it defaults to 24-hour clock interpretation, but will try to auto-adjust if the resulting time is in the past.
-    Reminders aren't yet saved to any persistent storage, and will be lost if the bot restarts, so don't rely on it for anything extremely important.
     """,
     )
     async def remind(self, ctx: commands.Context, time: str, *, text: str):
@@ -390,7 +389,7 @@ class Reminder(BaseCog):
         description=f"""
     __**remcancel**__
     Cancel a reminder.
-    If you have only a single reminder set, will cancel that one when ID is omitted. 
+    If you have only a single reminder set, this will cancel it when ID is omitted.
     """,
     )
     async def remcancel(self, ctx: commands.Context, id: typing.Optional[int] = None):

--- a/py/src/cogs/remind_cog.py
+++ b/py/src/cogs/remind_cog.py
@@ -8,6 +8,7 @@ import config
 import dateparser
 import discord
 from cmds import swap_hybrid_command_description
+from cogs.base_cog import BaseCog
 from discord.ext import commands, tasks
 from utils import *
 
@@ -81,9 +82,9 @@ def contains_am_or_pm(timestr: str):
     return timestr.find("AM") >= 0 or timestr.find("PM") >= 0
 
 
-class Reminder(commands.Cog):
+class Reminder(BaseCog):
     def __init__(self, bot) -> None:
-        self.bot: commands.Bot = bot
+        super().__init__(bot)
         self.reminders: dict[int, RemindEntry] = {}
         self.next_id: int = 1
 

--- a/py/src/cogs/remind_cog.py
+++ b/py/src/cogs/remind_cog.py
@@ -18,7 +18,6 @@ CHECK_INTERVAL_SECONDS = 15
 
 REMIND_BUTTON_TEXT_ADD = "Remind me too!"
 REMIND_BUTTON_TEXT_REMOVE = "Don't remind me."
-REMIND_TARGET_SEPARATOR = " ⇒ "
 
 DEFAULT_TIMEZONE = ZoneInfo(config.DEFAULT_TIMEZONE_NAME)
 
@@ -26,28 +25,105 @@ DEFAULT_TIMEZONE = ZoneInfo(config.DEFAULT_TIMEZONE_NAME)
 class RemindEntry:
     def __init__(
         self,
-        context: commands.Context,
-        message: str,
+        text: str,
         time: datetime,
+        context: commands.Context,
         targets: list[discord.User | discord.Member],
         reply: discord.Message | None = None,
     ) -> None:
-        self.context = context
-        self.message = message
+        self.text = text
         self.time = time
-        self.targets = targets
-        self.reply = reply
+        self.target_ids = [t.id for t in targets]
+        self.author_id = context.author.id
+        self.channel_id = context.channel.id
+        self.request_id = context.message.id
+        if context.interaction:
+            self.interaction = True
+        else:
+            self.interaction = False
+
+        self.response_id = reply.id if reply else None
+
+        self._request = context.message
+        self._context = context
 
     def __repr__(self) -> str:
-        return f"At {short_format_time(self.time)} for {','.join((u.name for u in self.targets))}: {self.message}"
+        return f"Reminder at {short_format_time(self.time)} for {','.join(str(tid) for tid in self.target_ids)}: {self.text}"
 
-    async def send(self):
-        reminders = self.target_mentions()
-        decorated = reminders + "\nReminder: " + self.message
-        if isinstance(self.context, commands.Context):
-            await reply(self.context, decorated)
-        else:
-            await send_safe(self.context, decorated)
+    def __getstate__(self):
+        # Exclude deep discord objects from pickling
+        state = self.__dict__.copy()
+        if "_request" in state:
+            state["_request"] = None
+        if "_context" in state:
+            state["_context"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if "_request" not in state:
+            log.info("Restoring request none state")
+            self._request = None
+        if "_context" not in state:
+            log.info("Restoring context none state")
+            self._context = None
+
+    async def describe(self, bot: commands.Bot) -> str:
+        targets = (u.name for u in await self.get_targets(bot))
+        return f"At {short_format_time(self.time)} for {','.join(targets)}: {self.text}"
+
+    def get_request(self, bot: commands.Bot) -> discord.PartialMessage:
+        if self._request is None:
+            self._request = discord.PartialMessage(
+                channel=bot.get_partial_messageable(self.channel_id), id=self.request_id
+            )
+        return self._request
+
+    async def get_context(self, bot: commands.Bot) -> commands.Context:
+        if self._context is None:
+            log.info(
+                f"channel id: {self.channel_id}, req message id: {self.request_id}"
+            )
+            c = bot.get_partial_messageable(self.channel_id)
+            if c is None:
+                c = await bot.fetch_channel(self.channel_id)
+            if not isinstance(c, discord.abc.Messageable):
+                raise RuntimeError(
+                    f"Failed to get context (reminder is not in a text channel). {self}"
+                )
+            m = None
+            if self.interaction:
+                if self.response_id:
+                    m = await c.fetch_message(self.response_id)
+                else:
+                    raise RuntimeError(
+                        f"Can't find message corresponding to reminder interaction. {self}"
+                    )
+            else:
+                m = await c.fetch_message(self.request_id)
+            self._context = await bot.get_context(m)
+        return self._context
+
+    async def get_targets(self, bot: commands.Bot) -> list[discord.User]:
+        users = []
+        for tid in self.target_ids:
+            u = bot.get_user(tid)
+            if u is None:
+                u = await bot.fetch_user(tid)
+            users.append(u)
+        return users
+
+    def get_response(self, bot: commands.Bot) -> discord.PartialMessage | None:
+        if self.response_id is None:
+            return None
+        return discord.PartialMessage(
+            channel=bot.get_partial_messageable(self.channel_id), id=self.response_id
+        )
+
+    async def send(self, bot: commands.Bot):
+        reminders = await self.target_mentions(bot)
+        decorated = reminders + "\nReminder: " + self.text
+        await reply(await self.get_context(bot), decorated)
 
     def should_send(self):
         return self.time < (
@@ -55,22 +131,17 @@ class RemindEntry:
             + timedelta(seconds=CHECK_INTERVAL_SECONDS)
         )
 
-    def get_targets(self):
-        return self.targets
-
-    def target_mentions(self):
-        return " ".join((usr.mention for usr in self.targets))
+    async def target_mentions(self, bot: commands.Bot):
+        return " ".join((usr.mention for usr in await self.get_targets(bot)))
 
     def was_authored_by(self, user: discord.User | discord.Member) -> bool:
-        return (
-            isinstance(self.context, commands.Context) and self.context.author is user
-        )
+        return self.author_id is user.id
 
     def is_user_involved(self, user: discord.User | discord.Member) -> bool:
-        return self.was_authored_by(user) or (user in self.get_targets())
+        return self.was_authored_by(user) or (user.id in self.target_ids)
 
-    def delta_from_creation(self) -> timedelta:
-        return self.time - self.context.message.created_at.replace(microsecond=0)
+    def delta_from_creation(self, bot: commands.Bot) -> timedelta:
+        return self.time - self.get_request(bot).created_at.replace(microsecond=0)
 
 
 def short_format_time(time: datetime):
@@ -82,7 +153,17 @@ def contains_am_or_pm(timestr: str):
     return timestr.find("AM") >= 0 or timestr.find("PM") >= 0
 
 
+def too_far_in_past(time: datetime):
+    return time < (
+        datetime.now(tz=time.tzinfo) - timedelta(seconds=CHECK_INTERVAL_SECONDS)
+    )
+
+
 class Reminder(BaseCog):
+
+    REMINDER_STORAGE_KEY = "remind"
+    REMINDER_COUNTER_STORAGE_KEY = "remind_count"
+
     def __init__(self, bot) -> None:
         super().__init__(bot)
         self.reminders: dict[int, RemindEntry] = {}
@@ -91,6 +172,8 @@ class Reminder(BaseCog):
         swap_hybrid_command_description(self.remind)
         swap_hybrid_command_description(self.remlist)
         swap_hybrid_command_description(self.remcancel)
+
+        self.load_stored_reminders()
         self.reminder_loop.start()
 
     def cog_unload(self) -> None:
@@ -101,39 +184,63 @@ class Reminder(BaseCog):
         done = []
         for id, entry in self.reminders.items():
             if entry.should_send():
-                await entry.send()
-                if entry.reply:
-                    await entry.reply.edit(
+                await entry.send(self.bot)
+                response = entry.get_response(self.bot)
+                if response:
+                    await response.edit(
                         content=self.reminder_set_message(id), view=None
                     )
                 done.append(id)
         for id in done:
             self.cancel(id)
 
+    @reminder_loop.before_loop
+    async def bot_wait_reminder_loop(self):
+        await self.bot.wait_until_ready()
+
+    def load_stored_reminders(self):
+        try:
+            self.reminders = self.bot.get_storage().get(Reminder.REMINDER_STORAGE_KEY)
+            self.next_id = self.bot.get_storage().get(
+                Reminder.REMINDER_COUNTER_STORAGE_KEY
+            )
+        except KeyError as e:
+            log.error(f"No reminder data found in storage.", e)
+
+    def update_storage(self):
+        self.bot.get_storage().set(Reminder.REMINDER_STORAGE_KEY, self.reminders)
+        self.bot.get_storage().set(Reminder.REMINDER_COUNTER_STORAGE_KEY, self.next_id)
+
     def add_to_reminder(
         self, entry_id: int, user: discord.User | discord.Member
     ) -> None:
         if entry_id not in self.reminders:
             raise ValueError(f"The specified reminder isn't valid (#{entry_id}).")
-        if user in self.reminders[entry_id].get_targets():
+        if user.id in self.reminders[entry_id].target_ids:
             raise ValueError(f"Already included in the reminder.")
-        self.reminders[entry_id].targets.append(user)
+        self.reminders[entry_id].target_ids.append(user.id)
 
     def remove_from_reminder(
         self, entry_id: int, user: discord.User | discord.Member
     ) -> None:
         if entry_id not in self.reminders:
             raise ValueError(f"The specified reminder isn't valid (#{entry_id}).")
-        self.reminders[entry_id].targets.remove(user)
+        self.reminders[entry_id].target_ids.remove(user.id)
 
     def reminder_set_message(self, entry_id: int):
         if entry_id not in self.reminders:
             return f"Reminder #{entry_id} not found."
         entry = self.reminders[entry_id]
-        return f"Reminder #{entry_id} set for {short_format_time(entry.time)}. (in {entry.delta_from_creation()})"
+        return f"Reminder #{entry_id} set for {short_format_time(entry.time)}. (in {entry.delta_from_creation(self.bot)})"
+
+    def _add_reminder(self, entry_id: int, entry: RemindEntry):
+        self.reminders[entry_id] = entry
+        self.update_storage()
 
     def cancel(self, entry_id: int):
-        return self.reminders.pop(entry_id)
+        cancelled = self.reminders.pop(entry_id)
+        self.update_storage()
+        return cancelled
 
     def build_parse_settings_future(self):
         return {
@@ -147,9 +254,6 @@ class Reminder(BaseCog):
             "PREFER_DAY_OF_MONTH": "first",
             "TIMEZONE": config.DEFAULT_TIMEZONE_NAME,
         }
-
-    def too_far_in_past(self, time: datetime):
-        return time < (datetime.now(tz=time.tzinfo) - timedelta(minutes=1))
 
     @commands.hybrid_command(
         aliases=["rem"],
@@ -189,7 +293,7 @@ class Reminder(BaseCog):
                     closer_time = closer_time.replace(tzinfo=DEFAULT_TIMEZONE)
                 # sensibly override AM/PM if it seems off (in the past)
                 if (
-                    self.too_far_in_past(closer_time)
+                    too_far_in_past(closer_time)
                     and closer_time.hour < 12
                     and not contains_am_or_pm(time)
                 ):
@@ -200,14 +304,14 @@ class Reminder(BaseCog):
         if (
             time_ambiguous
             and closer_time is not None
-            and not self.too_far_in_past(closer_time)
+            and not too_far_in_past(closer_time)
             and closer_time < parsed_time
         ):
             parsed_time = closer_time
             detail_message += f" (assuming today rather than tomorrow)"
 
         # fail if more than 1 minute in the past
-        if self.too_far_in_past(parsed_time):
+        if too_far_in_past(parsed_time):
             await reply(
                 ctx,
                 f"Time ({short_format_time(parsed_time)}) is in the past!"
@@ -217,14 +321,17 @@ class Reminder(BaseCog):
 
         log.info(f"setting reminder for time: {short_format_time(parsed_time)}")
         parsed_time = parsed_time.replace(microsecond=0)
-        self.reminders[entry_id] = RemindEntry(
-            context=ctx, message=text, time=parsed_time, targets=[ctx.author]
+        entry = RemindEntry(
+            text=text, time=parsed_time, context=ctx, targets=[ctx.author]
         )
-        self.reminders[entry_id].reply = await reply(
+        self._add_reminder(entry_id, entry)
+        response = await reply(
             ctx,
             f"{self.reminder_set_message(entry_id)}{detail_message}",
             view=ReminderView(self, entry_id),
         )
+        if response:
+            entry.response_id = response.id
 
     @remind.error
     async def remind_error(self, ctx: commands.Context, error):
@@ -246,7 +353,7 @@ class Reminder(BaseCog):
         to_join = []
         for id, entry in self.reminders.items():
             if entry.is_user_involved(ctx.author):
-                to_join.append(f"#{id}: {entry}")
+                to_join.append(f"#{id}: {await entry.describe(self.bot)}")
         if len(to_join) == 0:
             await reply(ctx, "You have no pending reminders.")
         else:
@@ -269,7 +376,7 @@ class Reminder(BaseCog):
                 await reply(ctx, "You aren't involved in this reminder.")
                 return
             re = self.cancel(id)
-            await reply(ctx, f"Cancelled reminder: {re}")
+            await reply(ctx, f"Cancelled reminder: {await re.describe(self.bot)}")
         else:
             pending = []
             for id, entry in self.reminders.items():
@@ -285,8 +392,9 @@ class Reminder(BaseCog):
                 )
                 return
             re = self.cancel(pending[0])
-            if re.reply:
-                await re.reply.edit(content="Reminder cancelled.", view=None)
+            response = re.get_response(self.bot)
+            if response:
+                await response.edit(content="Reminder cancelled.", view=None)
             await reply(ctx, f"Cancelled reminder: {re}")
 
 
@@ -296,7 +404,11 @@ class ReminderView(discord.ui.View):
         self.entry_id = entry_id
         super().__init__(timeout=None)
 
-    @discord.ui.button(label=REMIND_BUTTON_TEXT_ADD, style=discord.ButtonStyle.blurple)
+    @discord.ui.button(
+        label=REMIND_BUTTON_TEXT_ADD,
+        style=discord.ButtonStyle.blurple,
+        custom_id="reminder_view:me_too",
+    )
     async def me_too_pressed(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ):
@@ -311,12 +423,14 @@ class ReminderView(discord.ui.View):
         content = (
             self.rcog.reminder_set_message(self.entry_id)
             + " "
-            + self.rcog.reminders[self.entry_id].target_mentions()
+            + await self.rcog.reminders[self.entry_id].target_mentions(self.rcog.bot)
         )
         await interaction.response.edit_message(content=content, view=self)
 
     @discord.ui.button(
-        label=REMIND_BUTTON_TEXT_REMOVE, style=discord.ButtonStyle.blurple
+        label=REMIND_BUTTON_TEXT_REMOVE,
+        style=discord.ButtonStyle.blurple,
+        custom_id="reminder_view:remove_me",
     )
     async def remove_me_pressed(
         self, interaction: discord.Interaction, button: discord.ui.Button
@@ -331,7 +445,7 @@ class ReminderView(discord.ui.View):
             )
             return
 
-        if len(self.rcog.reminders[self.entry_id].get_targets()) == 0:
+        if len(self.rcog.reminders[self.entry_id].target_ids) == 0:
             # cancel the reminder if there are no targets remaining
             self.rcog.cancel(self.entry_id)
             await interaction.response.edit_message(
@@ -342,6 +456,6 @@ class ReminderView(discord.ui.View):
         content = (
             self.rcog.reminder_set_message(self.entry_id)
             + " "
-            + self.rcog.reminders[self.entry_id].target_mentions()
+            + await self.rcog.reminders[self.entry_id].target_mentions(self.rcog.bot)
         )
         await interaction.response.edit_message(content=content, view=self)

--- a/py/src/config.py
+++ b/py/src/config.py
@@ -13,3 +13,4 @@ COMMAND_TIMEOUT = 10.0  # in seconds
 INVISIBLE_SPACE = "\u200b"
 DEFAULT_TIMEZONE_NAME = "US/Eastern"
 BOT_DESCRIPTION = "mid-bot is an experimental bot with a variety of commands."
+LOCAL_STORAGE_FILENAME = "mid.data"

--- a/py/src/config.py
+++ b/py/src/config.py
@@ -14,4 +14,4 @@ INVISIBLE_SPACE = "\u200b"
 DEFAULT_TIMEZONE_NAME = "US/Eastern"
 BOT_DESCRIPTION = "mid-bot is an experimental bot with a variety of commands."
 LOCAL_STORAGE_FILENAME = "mid.data"
-STORAGE_SAVE_INTERVAL = 30.0  # in seconds
+STORAGE_SAVE_INTERVAL = 300.0  # in seconds

--- a/py/src/config.py
+++ b/py/src/config.py
@@ -14,3 +14,4 @@ INVISIBLE_SPACE = "\u200b"
 DEFAULT_TIMEZONE_NAME = "US/Eastern"
 BOT_DESCRIPTION = "mid-bot is an experimental bot with a variety of commands."
 LOCAL_STORAGE_FILENAME = "mid.data"
+STORAGE_SAVE_INTERVAL = 30.0  # in seconds

--- a/py/src/main.py
+++ b/py/src/main.py
@@ -2,7 +2,14 @@
 import logging
 import os
 
+import cmds
+from bongo import bongo
 from client import MidClient
+from cogs.artificial_cog import Intelligence
+from cogs.cards_cog import Cards
+from cogs.deafen_cog import Deafener
+from cogs.dice_cog import DiceRoller
+from cogs.remind_cog import Reminder
 from dotenv import load_dotenv
 
 log = logging.getLogger(__name__)
@@ -18,6 +25,9 @@ if DISCORD_TOKEN == None:
 
 if __name__ == "__main__":
     log.info("Starting bot...")
-    client = MidClient()
+    client = MidClient(
+        misc_commands=[cmds.echo, cmds.shrug, cmds.eject, bongo],
+        misc_cogs=[Intelligence, Cards, Deafener, DiceRoller, Reminder],
+    )
     client.run(DISCORD_TOKEN)
     log.info("Bot stopped running.")

--- a/py/src/main.py
+++ b/py/src/main.py
@@ -9,6 +9,7 @@ from cogs.artificial_cog import Intelligence
 from cogs.cards_cog import Cards
 from cogs.deafen_cog import Deafener
 from cogs.dice_cog import DiceRoller
+from cogs.maintenance_cog import Maintenance
 from cogs.remind_cog import Reminder
 from dotenv import load_dotenv
 
@@ -27,7 +28,7 @@ if __name__ == "__main__":
     log.info("Starting bot...")
     client = MidClient(
         misc_commands=[cmds.echo, cmds.shrug, cmds.eject, bongo],
-        misc_cogs=[Intelligence, Cards, Deafener, DiceRoller, Reminder],
+        misc_cogs=[Intelligence, Cards, Deafener, DiceRoller, Maintenance, Reminder],
     )
     client.run(DISCORD_TOKEN)
     log.info("Bot stopped running.")

--- a/py/src/utils.py
+++ b/py/src/utils.py
@@ -53,13 +53,13 @@ async def send_safe(
 # Send `text` as a reply in the given context `ctx`.
 # Set `mention` to true to include an @ mention. Behavior if unset is to mention if not a slash command.
 async def reply(
-    ctx: commands.Context,
+    ctx: commands.Context | discord.abc.Messageable,
     text: str | None = None,
     mention: typing.Optional[bool] = None,
     **kwargs,
 ):
     payload = text
-    if text:
+    if text and isinstance(ctx, commands.Context):
         payload = f"{(ctx.author.mention + ' ') if mention else ''}{text}"
     return await send_safe(ctx=ctx, text=payload, **kwargs)
 


### PR DESCRIPTION
This gives the bot the ability to locally store data that persists between restarts.
Since python's shelve is used for this, such data must be pickle-able. Classes designed to be synced with the data manager are already well suited for this.
Data is persisted for dice macros, the card deck, and reminders.
Reminder entries are significantly restructured to allow for them to be saved.